### PR TITLE
bugfix: AIRFLOW_REDIS_USE_SSL is used to control database SSL option

### DIFF
--- a/1/debian-10/rootfs/opt/bitnami/scripts/libairflow.sh
+++ b/1/debian-10/rootfs/opt/bitnami/scripts/libairflow.sh
@@ -222,7 +222,7 @@ airflow_configure_base_url() {
 }
 
 ########################
-# Configure Airflow webserver authentication 
+# Configure Airflow webserver authentication
 # Globals:
 #   AIRFLOW_*
 # Arguments:
@@ -291,7 +291,7 @@ airflow_configure_database() {
     local -r user=$(airflow_encode_url "$AIRFLOW_DATABASE_USERNAME")
     local -r password=$(airflow_encode_url "$AIRFLOW_DATABASE_PASSWORD")
     local extra_options
-    is_boolean_yes "$AIRFLOW_REDIS_USE_SSL" && extra_options="?sslmode=require"
+    is_boolean_yes "$AIRFLOW_DATABASE_USE_SSL" && extra_options="?sslmode=require"
 
     info "Configuring Airflow database"
     airflow_conf_set "core" "sql_alchemy_conn" "postgresql+psycopg2://${user}:${password}@${AIRFLOW_DATABASE_HOST}:${AIRFLOW_DATABASE_PORT_NUMBER}/${AIRFLOW_DATABASE_NAME}${extra_options:-}"
@@ -352,7 +352,7 @@ airflow_configure_celery_executor() {
     local -r database_user=$(airflow_encode_url "$AIRFLOW_DATABASE_USERNAME")
     local -r database_password=$(airflow_encode_url "$AIRFLOW_DATABASE_PASSWORD")
     local database_extra_options
-    is_boolean_yes "$AIRFLOW_REDIS_USE_SSL" && database_extra_options="?sslmode=require"
+    is_boolean_yes "$AIRFLOW_DATABASE_USE_SSL" && database_extra_options="?sslmode=require"
     airflow_conf_set "celery" "result_backend" "db+postgresql://${database_user}:${database_password}@${AIRFLOW_DATABASE_HOST}:${AIRFLOW_DATABASE_PORT_NUMBER}/${AIRFLOW_DATABASE_NAME}${database_extra_options:-}"
 }
 

--- a/2/debian-10/rootfs/opt/bitnami/scripts/libairflow.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/libairflow.sh
@@ -222,7 +222,7 @@ airflow_configure_base_url() {
 }
 
 ########################
-# Configure Airflow webserver authentication 
+# Configure Airflow webserver authentication
 # Globals:
 #   AIRFLOW_*
 # Arguments:
@@ -291,7 +291,7 @@ airflow_configure_database() {
     local -r user=$(airflow_encode_url "$AIRFLOW_DATABASE_USERNAME")
     local -r password=$(airflow_encode_url "$AIRFLOW_DATABASE_PASSWORD")
     local extra_options
-    is_boolean_yes "$AIRFLOW_REDIS_USE_SSL" && extra_options="?sslmode=require"
+    is_boolean_yes "$AIRFLOW_DATABASE_USE_SSL" && extra_options="?sslmode=require"
 
     info "Configuring Airflow database"
     airflow_conf_set "core" "sql_alchemy_conn" "postgresql+psycopg2://${user}:${password}@${AIRFLOW_DATABASE_HOST}:${AIRFLOW_DATABASE_PORT_NUMBER}/${AIRFLOW_DATABASE_NAME}${extra_options:-}"
@@ -352,7 +352,7 @@ airflow_configure_celery_executor() {
     local -r database_user=$(airflow_encode_url "$AIRFLOW_DATABASE_USERNAME")
     local -r database_password=$(airflow_encode_url "$AIRFLOW_DATABASE_PASSWORD")
     local database_extra_options
-    is_boolean_yes "$AIRFLOW_REDIS_USE_SSL" && database_extra_options="?sslmode=require"
+    is_boolean_yes "$AIRFLOW_DATABASE_USE_SSL" && database_extra_options="?sslmode=require"
     airflow_conf_set "celery" "result_backend" "db+postgresql://${database_user}:${database_password}@${AIRFLOW_DATABASE_HOST}:${AIRFLOW_DATABASE_PORT_NUMBER}/${AIRFLOW_DATABASE_NAME}${database_extra_options:-}"
 }
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

the `libairflow.sh` script uses `AIRFLOW_REDIS_USE_SSL` environment variable to control SSL flag for both redis and the database.

**Benefits**

This change will allow users to specify SSL flags for each element independently

**Possible drawbacks**

this change could cause issues on existing setup if the environment variables aren't specified properly

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
