### PR TITLE
Add Webserer Start Waiting Log Information

### DIFF
--- a/2/debian-10/rootfs/opt/bitnami/scripts/libairflowscheduler.sh
+++ b/2/debian-10/rootfs/opt/bitnami/scripts/libairflowscheduler.sh
@@ -69,6 +69,7 @@ airflow_scheduler_initialize() {
     done
 
     # Wait for airflow webserver to be available
+    info "Waiting for Airflow Webserser to be up"
     airflow_scheduler_wait_for_webserver "$AIRFLOW_WEBSERVER_HOST" "$AIRFLOW_WEBSERVER_PORT_NUMBER"
     [[ "$AIRFLOW_EXECUTOR" == "CeleryExecutor" || "$AIRFLOW_EXECUTOR" == "CeleryKubernetesExecutor"  ]] && wait-for-port --host "$REDIS_HOST" "$REDIS_PORT_NUMBER"
 

--- a/2/debian-11/rootfs/opt/bitnami/scripts/libairflowscheduler.sh
+++ b/2/debian-11/rootfs/opt/bitnami/scripts/libairflowscheduler.sh
@@ -69,6 +69,7 @@ airflow_scheduler_initialize() {
     done
 
     # Wait for airflow webserver to be available
+    info "Waiting for Airflow Webserser to be up"
     airflow_scheduler_wait_for_webserver "$AIRFLOW_WEBSERVER_HOST" "$AIRFLOW_WEBSERVER_PORT_NUMBER"
     [[ "$AIRFLOW_EXECUTOR" == "CeleryExecutor" || "$AIRFLOW_EXECUTOR" == "CeleryKubernetesExecutor"  ]] && wait-for-port --host "$REDIS_HOST" "$REDIS_PORT_NUMBER"
 


### PR DESCRIPTION
Signed-off-by: addisonjones-gc <addison.jones@gocaribou.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
The scope of this change is minor and adds a logging information message similar to the [worker image](https://github.com/bitnami/bitnami-docker-airflow-worker) while the scheduler is waiting for the webserver to be up. This reduces some confusion if the `wait-for-port` function [returns a timeout message](https://github.com/bitnami/wait-for-port/blob/v1.0.3/cmd.go#L63).

**Benefits**

<!-- What benefits will be realized by the code change? -->
Added clarity to the fact that the scheduler also waits for the webserver to be up.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
N/A

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
